### PR TITLE
Split the dedup script to 3 stages to scale up to multiple machines

### DIFF
--- a/pile/processing/dedup/stages_dedup/clustering.py
+++ b/pile/processing/dedup/stages_dedup/clustering.py
@@ -1,0 +1,190 @@
+"""
+Given a list file each with minhashes as the entries generate from `generate_minhash.py`, perform clustering and deduplication.
+The input files are generated from `generate_minhash.py` and should have the suffix `_minhash`.
+
+Output is a series of files each is a boolean array with 'True' indicating the entry is a duplicate corresponding to the input files.
+Output filename are the same as the input filename with the suffix `_filter_idx`.
+
+Example:
+Assume there are dataset file `StackExchange_minhash` and `AI4Code_minhash` in the list file `minhash_dataset_list.txt` (one path per line)
+Outputs are `StackExchange_minhash_filter_idx` and `AI4Code_minhash_filter_idx` files in the same directory as the corresponding input files
+`python clustering.py --minhash_dataset_list_file minhash_dataset_list.txt`
+"""
+from __future__ import annotations
+from datasets import load_dataset, load_from_disk, Dataset, concatenate_datasets
+import json
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# author      : Chenghao Mou (mouchenghao@gmail.com)
+# created     : 10/4/22
+
+import gc
+import hashlib
+import logging
+import multiprocessing as mp
+import os
+import random
+import re
+import struct
+import time
+import warnings
+from collections import defaultdict
+from itertools import tee
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Tuple
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    import datasets
+    import numpy as np
+    import typer
+    from datasets import load_dataset
+    from scipy.integrate import quad as integrate
+    from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+datasets.logging.set_verbosity_error()
+class UnionFind:
+    def __init__(self):
+        self.parent: Dict[int, int] = {}
+
+    def find(self, x):
+        if x not in self.parent:
+            self.parent[x] = x
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+
+    def union(self, x, y):
+        px = self.find(x)
+        py = self.find(y)
+        self.parent[px] = self.parent[py] = min(px, py)
+
+
+if __name__ == "__main__":
+    def run(
+        minhash_dataset_list_file: str = typer.Option(..., help="minhash dataset paths to dedup. One path for each line"),  # noqa: E501
+    ):
+        global uf
+
+        logging.basicConfig(level=logging.INFO)
+
+        start_time = time.time()
+        time_measures = {}
+
+        # Checking the minhash_dataset_list_file is valid format
+        minhash_dataset_paths = []
+        with open(minhash_dataset_list_file, "r") as f:
+            lines = f.read().splitlines()
+            for line in lines:
+                minhash_dataset_path = line.strip()
+                minhash_dataset_paths.append(minhash_dataset_path)
+                # check if the path is valid and is a directory
+                assert os.path.isdir(minhash_dataset_path.strip())
+                # check if the path is a minhash dataset (ends with _minhash)
+                assert minhash_dataset_path.strip().endswith("_minhash")
+                # check if it is a hugging face dataset format by checking if it has a dataset_info.json
+                assert os.path.isfile(os.path.join(minhash_dataset_path.strip(), "dataset_info.json"))
+
+        print('loading all the minhash datasets...')
+        time_measures["load_minhash"] = time.time()
+        minhash_datasets = {}
+        offset_store = {}
+        offset = 0
+        for minhash_dataset_path in minhash_dataset_paths:
+            offset_store[minhash_dataset_path] = offset
+            dataset = load_from_disk(minhash_dataset_path.strip())
+            minhash_datasets[minhash_dataset_path] = dataset
+            # update the offset for the next dataset
+            offset += len(dataset)
+
+        # concatenate all the minhashes to one dataset
+        embedded = concatenate_datasets(list(minhash_datasets.values()))
+        time_measures["load_minhash"] = time.time() - time_measures["load_minhash"]
+
+        print('output will be saved to the following files:')
+        outputs = dict()
+        for minhash_dataset_path in minhash_dataset_paths:
+            
+            print(minhash_dataset_path)
+            print(minhash_dataset_path[:-len("_minhash")])
+            outputs[minhash_dataset_path] = minhash_dataset_path[:-len("_minhash")] + "_filter_idx"
+            print(outputs[minhash_dataset_path])
+
+        time_measures["clustering"] = time.time()
+
+        # get the first element of the dataset
+        first = embedded[0]
+        B = len(first['__signatures__'])
+        batch_size: int = 10000
+        for table_idx in range(B):
+            new_hash_table = defaultdict(set)
+            for i in tqdm(
+                range(0, len(embedded), batch_size), dynamic_ncols=True, desc="Iterating MinHashes..."  # noqa: E501
+            ):
+                batch = embedded[i : i + batch_size]
+                for tmp_idx, Hs in enumerate(batch["__signatures__"]):
+                    #TODO check if it is correct
+                    new_hash_table[Hs[table_idx]].add(i + tmp_idx)
+
+            for cluster in new_hash_table.values():
+                if len(cluster) <= 1:
+                    continue
+                idx = min(cluster)
+                for x in cluster:
+                    uf.union(x, idx)
+
+        time_measures["clustering"] = time.time() - time_measures["clustering"]
+
+        time_measures["filtering_idx"] = time.time()
+        gc.freeze()
+        gc.disable()
+        final_data = embedded.map(
+            function=lambda _, idx: {"__filter__": uf.find(idx) !=  idx},
+            with_indices=True,
+            num_proc=os.cpu_count(),
+            new_fingerprint=str(random.getrandbits(128)),
+            desc="Finding clusters...",
+        )
+        gc.enable()
+        gc.collect()
+        time_measures["filtering_idx"] = time.time() - time_measures["filtering_idx"]
+
+        final_data = final_data.remove_columns(["__signatures__"])
+        NUM_TRUE_LABEL = sum(final_data['__filter__'])
+        print('Total Number of idx to be filtered', NUM_TRUE_LABEL)
+
+        print('saving filter idx data...')
+        time_measures["save"] = time.time()
+        for minhash_dataset_path in minhash_dataset_paths:
+            offset = offset_store[minhash_dataset_path]
+            size = len(minhash_datasets[minhash_dataset_path])
+            output = outputs[minhash_dataset_path]
+            filter_idx = final_data.select(range(offset, offset + size))
+            filter_idx.save_to_disk(output)
+            print(f"saved to {output}")
+        time_measures["save"] = time.time() - time_measures["save"]
+
+        PAD = 32
+
+        MINHASH_DATA_SIZE = len(embedded)
+
+        for key, value in time_measures.items():
+            logger.info(f"{key:<{PAD}}: {value:.2f} seconds")
+        logger.info(
+            f"{'Number of input minhash':<{PAD}}: {MINHASH_DATA_SIZE} "  # noqa: E501
+        )
+        logger.info(f"{'Duplicate Number':<{PAD}}: {NUM_TRUE_LABEL} ({NUM_TRUE_LABEL / MINHASH_DATA_SIZE:.2%})")  # noqa: E501
+        logger.info(f"{'Total Time':<{PAD}}: {time.time() - start_time:.2f} seconds")
+        logger.info(f"{'Filtered Index Dataset':<{PAD}}: {output}")
+        logger.info(f"{'Finish generating filtered index from':<{PAD}}: {minhash_dataset_path}")
+        logger.info("🤗 Happy Deduplicating 🤗")
+
+    mp.set_start_method("fork", force=True)
+    uf = UnionFind()
+    typer.run(run)

--- a/pile/processing/dedup/stages_dedup/filtering.py
+++ b/pile/processing/dedup/stages_dedup/filtering.py
@@ -1,0 +1,109 @@
+"""
+Given a filter indicator file and a dataset file, filter the dataset.
+The filter indicator file is a boolean array with 'True' indicating the entry is a duplicate corresponding to the input dataset.
+The filter indicator file is generated from `clustering.py` and should have the suffix `_filter_idx`.
+Example:
+Assume there is a dataset file `StackExchange` and a filter indicator file `StackExchange_filter_idx`
+Output will be `StackExchange_filtered`
+`python filtering.py --dataset_path StackExchange --filter_idx_path StackExchange_filter_idx`
+"""
+from __future__ import annotations
+from datasets import load_dataset, load_from_disk, Dataset, concatenate_datasets
+import json
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# author      : Chenghao Mou (mouchenghao@gmail.com)
+# created     : 10/4/22
+
+import gc
+import hashlib
+import logging
+import multiprocessing as mp
+import os
+import random
+import re
+import struct
+import time
+import warnings
+from collections import defaultdict
+from itertools import tee
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Tuple
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    import datasets
+    import numpy as np
+    import typer
+    from datasets import load_dataset
+    from scipy.integrate import quad as integrate
+    from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+datasets.logging.set_verbosity_error()
+
+if __name__ == "__main__":
+    def run(
+        dataset_path: str = typer.Option(..., help="dataset to filter"),  # noqa: E501
+        filter_idx_path: str = typer.Option(..., help="filter indicator dataset"),  # noqa: E501
+        output_path: str = typer.Option(None, help="output path. If not set, would set to to dataset_path with suffix 'filtered'"),  # noqa: E501
+    ):
+        global uf
+
+        logging.basicConfig(level=logging.INFO)
+        # check if the filter_idx_path is ended with 'filter_idx'
+        assert filter_idx_path.strip().endswith("filter_idx"), "filter_idx_path must end with 'filter_idx'"
+
+        if output_path is None:
+            output_path = dataset_path + "_filtered"
+        typer.echo(f"output is saved to {output_path}")
+
+        start_time = time.time()
+        time_measures = {}
+        # load the dataset from dataset_path
+        time_measures["load_dataset"] = time.time()
+        dataset = load_from_disk(dataset_path)
+        time_measures["load_dataset"] = time.time() - time_measures["load_dataset"]
+        INPUT_DATA_SIZE = len(dataset)
+        # load the dataset from filter_idx_path
+        time_measures["load_filter_idx"] = time.time()
+        filter_idx_dataset = load_from_disk(filter_idx_path)
+        time_measures["load_filter_idx"] = time.time() - time_measures["load_filter_idx"]
+        # check if the dataset and filter_idx have the same number of rows
+        assert len(dataset) == len(filter_idx_dataset), "dataset and filter_idx must have the same number of rows"
+
+        # filtered out the dataset by filter_idx, if the filter_idx['__filter__'] is 1, then remove it, otherwise keep it
+        dataset = dataset.add_column('__filter__', filter_idx_dataset["__filter__"])
+        # we want to keep the data that has __filter__ == False
+        dataset = dataset.filter(lambda x: x['__filter__'] == False)
+
+        time_measures["save"] = time.time()
+        dataset.save_to_disk(output_path)
+        time_measures["save"] = time.time() - time_measures["save"]
+
+        FINAL_DATA_SIZE = len(dataset)
+        PAD = 32
+
+        DUP_SIZE = INPUT_DATA_SIZE - FINAL_DATA_SIZE
+
+        for key, value in time_measures.items():
+            logger.info(f"{key:<{PAD}}: {value:.2f} seconds")
+        logger.info(
+            f"{'Number of input data':<{PAD}}: {INPUT_DATA_SIZE} "  # noqa: E501
+        )
+        logger.info(
+            f"{'Data Number (after)':<{PAD}}: {FINAL_DATA_SIZE} ({FINAL_DATA_SIZE / INPUT_DATA_SIZE:.2%})"  # noqa: E501
+        )
+        logger.info(f"{'Duplicate Number':<{PAD}}: {DUP_SIZE} ({DUP_SIZE / INPUT_DATA_SIZE:.2%})")  # noqa: E501
+        logger.info(f"{'Total Time':<{PAD}}: {time.time() - start_time:.2f} seconds")
+        logger.info(f"{'Finish generating filtered dataset from':<{PAD}}: {dataset_path}")
+        logger.info(f"{'Finish saving filtered dataset to':<{PAD}}: {output_path}")
+        logger.info("🤗 Happy Deduplicating 🤗")
+
+    mp.set_start_method("fork", force=True)
+    typer.run(run)

--- a/pile/processing/dedup/stages_dedup/generate_minhash.py
+++ b/pile/processing/dedup/stages_dedup/generate_minhash.py
@@ -1,0 +1,267 @@
+"""
+Generate MinHash signatures for each document in the dataset.
+It generates a dataset with the following fields:
+    - __signatures__: a list of minhash signatures
+    - __id__: the id of the document (not used)
+The output file has the same name as the input file with the suffix "_minhash" under the same directory.
+
+"""
+from __future__ import annotations
+from datasets import load_dataset, load_from_disk, Dataset, concatenate_datasets
+import json
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# author      : Chenghao Mou (mouchenghao@gmail.com)
+# created     : 10/4/22
+
+import gc
+import hashlib
+import logging
+import multiprocessing as mp
+import os
+import random
+import re
+import struct
+import time
+import warnings
+from collections import defaultdict
+from itertools import tee
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Tuple
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    import datasets
+    import numpy as np
+    import typer
+    from datasets import load_dataset
+    from scipy.integrate import quad as integrate
+    from tqdm import tqdm
+
+
+SEED = 42
+NON_ALPHA = re.compile("[^A-Za-z_0-9]")
+RNG = np.random.RandomState(SEED)
+MAX_HASH = np.uint64((1 << 32) - 1)
+MERSENNE_PRIME = np.uint64((1 << 61) - 1)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+datasets.logging.set_verbosity_error()
+
+
+def ngrams(sequence: List[str], n: int) -> Iterable:
+    """
+    Directly taken from nltk package to avoid dependency.
+
+    Parameters
+    ----------
+    sequence : list
+        The sequence of items to be n-grammed.
+    n : int
+        The order of the n-grams to be extracted.
+
+    Returns
+    -------
+    Iterable
+        The n-grams generated from the sequence.
+    """
+    iterables = tee(sequence, n)
+    for i, sub_iterable in enumerate(iterables):
+        for _ in range(i):
+            next(sub_iterable, None)
+    return zip(*iterables)
+
+
+def sha1_hash32(data):
+    """
+    Directly taken from datasketch package to avoid dependency.
+
+    Parameters
+    ----------
+    data : bytes
+
+    Returns
+    -------
+    int
+    """
+    return struct.unpack("<I", hashlib.sha1(data).digest()[:4])[0]
+
+
+def embed_func(
+    content: str,
+    idx: int,
+    *,
+    num_perm: int,
+    ngram_size: int,
+    hashranges: List[Tuple[int, int]],
+    permutations: np.ndarray,
+) -> Dict[str, Any]:
+    """
+    Combined with some datasketch code to avoid dependency.
+
+    Parameters
+    ----------
+    content : str
+        The content to be embedded.
+    idx : int
+        The index of the content.
+    num_perm : int
+        The number of permutations.
+    ngram_size : int
+        The size of n-grams.
+    hashranges : List[Tuple[int, int]]
+        The ranges of hash values.
+    permutations : np.ndarray
+        The permutations for the minhash.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The hash values in each range and the index.
+    """
+    hashvalues = np.ones(num_perm, dtype=np.uint64) * MAX_HASH
+    tokens = {" ".join(t) for t in ngrams(NON_ALPHA.split(content), ngram_size)}
+    hv = np.array([sha1_hash32(token.encode("utf-8")) for token in tokens], dtype=np.uint64)  # noqa: E501
+    a, b = permutations
+    phv = np.bitwise_and(((hv * np.tile(a, (len(hv), 1)).T).T + b) % MERSENNE_PRIME, MAX_HASH)  # noqa: E501
+    hashvalues = np.vstack([phv, hashvalues]).min(axis=0)
+    Hs = [bytes(hashvalues[start:end].byteswap().data) for start, end in hashranges]
+    return {"__signatures__": Hs, "__id__": idx}
+
+
+def optimal_param(
+    threshold: float,
+    num_perm: int,
+    false_positive_weight: float = 0.5,
+    false_negative_weight: float = 0.5,
+):
+    """
+    Compute the optimal `MinHashLSH` parameter that minimizes the weighted sum
+    of probabilities of false positive and false negative, taken from datasketch.
+
+    Parameters
+    ----------
+    threshold : float
+        The threshold for similarity.
+    num_perm : int
+        The number of permutations.
+    false_positive_weight : float
+        The weight of false positive.
+    false_negative_weight : float
+        The weight of false negative.
+
+    Returns
+    -------
+    Tuple[int, int]
+        The optimal `b` and `r` parameters.
+    """
+
+    def false_positive_probability(threshold: float, b: int, r: int):
+        """Source: `datasketch.lsh`"""
+
+        def proba(s):
+            return 1 - (1 - s ** float(r)) ** float(b)
+
+        a, _ = integrate(proba, 0.0, threshold)
+        return a
+
+    def false_negative_probability(threshold: float, b: int, r: int):
+        """Source: `datasketch.lsh`"""
+
+        def proba(s):
+            return 1 - (1 - (1 - s ** float(r)) ** float(b))
+
+        a, _ = integrate(proba, threshold, 1.0)
+        return a
+
+    min_error = float("inf")
+    opt = (0, 0)
+    for b in range(1, num_perm + 1):
+        max_r = int(num_perm / b)
+        for r in range(1, max_r + 1):
+            fp = false_positive_probability(threshold, b, r)
+            fn = false_negative_probability(threshold, b, r)
+            error = fp * false_positive_weight + fn * false_negative_weight
+            if error < min_error:
+                min_error = error
+                opt = (b, r)
+    return opt
+
+if __name__ == "__main__":
+    def run(
+        dataset_path: str = typer.Option(..., help="The dataset to use"),  # noqa: E501
+        column: str = typer.Option(..., help="Dataset column"),
+        ngram_size: int = typer.Option(5, help="The ngram size to use for MinHash"),
+        num_perm: int = typer.Option(256, help="Number of permutations"),
+        threshold: float = typer.Option(0.7, help="Minhash threshold"),
+        output: str = typer.Option(None, help="Store the minhash of the dataset, None to store in the same dir of dataset_path but added 'minhash' as suffix"),
+    ):
+        # write the output in the same dir of dataset_path but added 'minhash' as suffix
+        if output is None:
+            # make sure the dataset_path does not end with a slash
+            assert(not dataset_path.strip().endswith("/"))
+            output = dataset_path + '_minhash'
+        typer.echo(f"Output will be stored in {output}")
+
+        logging.basicConfig(level=logging.INFO)
+
+        start_time = time.time()
+        time_measures = {}
+        B, R = optimal_param(threshold, num_perm)
+        HASH_RANGES = [(i * R, (i + 1) * R) for i in range(B)]
+        HASH_TABLES = [defaultdict(set) for _ in range(B)]
+        time_measures["load_dataset"] = time.time()
+        ds = load_from_disk(dataset_path)
+        time_measures["load_dataset"] = time.time() - time_measures["load_dataset"]
+        DATA_SIZE = len(ds)
+        PERMUTATIONS = np.array(
+            [
+                (
+                    RNG.randint(1, MERSENNE_PRIME, dtype=np.uint64),
+                    RNG.randint(0, MERSENNE_PRIME, dtype=np.uint64),
+                )
+                for _ in range(num_perm)
+            ],
+            dtype=np.uint64,
+        ).T
+
+        time_measures["minhash"] = time.time()
+        embedded = ds.map(
+            function=embed_func,
+            fn_kwargs={
+                "num_perm": num_perm,
+                "hashranges": HASH_RANGES,
+                "ngram_size": ngram_size,
+                "permutations": PERMUTATIONS,
+            },
+            input_columns=[column],
+            remove_columns=ds.column_names,
+            num_proc=os.cpu_count(),
+            with_indices=True,
+            desc="Fingerprinting...",
+        )
+        time_measures["minhash"] = time.time() - time_measures["minhash"]
+        time_measures["save_dataset"] = time.time()
+        embedded.save_to_disk(output)
+        time_measures["save_dataset"] = time.time() - time_measures["save_dataset"]
+
+        PAD = 32
+        MINHASH_DATA_SIZE = len(embedded)
+
+        for key, value in time_measures.items():
+            logger.info(f"{key:<{PAD}}: {value:.2f} seconds")
+        logger.info(f"{'Data size':<{PAD}}: {DATA_SIZE}")
+        logger.info(
+            f"{'Number of minhash generated':<{PAD}}: {MINHASH_DATA_SIZE} "  # noqa: E501
+        )
+        logger.info(f"{'Total Time':<{PAD}}: {time.time() - start_time:.2f} seconds")
+        logger.info(f"{'Minhash dataset file':<{PAD}}: {output}")
+        logger.info(f"Finish Generating Minhashes for {dataset_path}")
+        logger.info("🤗 Happy Deduplicating 🤗")
+
+    mp.set_start_method("fork", force=True)
+    typer.run(run)


### PR DESCRIPTION
The goal is to scale up the [near dedup script](https://github.com/CarperAI/pilev2/blob/ef21abe0ab4a6c25203ba35292af5c97b8f15e96/pile/processing/dedup/grouped_dedup.py) to multiple machines.
The 3 stages are minhash generation, clustering and filtering. We will divide the original script up and perform these stages separately in order to scale up. We detailed the three stages as follows.
## Stage 1: Minhash Generation
We would generate minhash for each document in each huggingface dataset file. This for now is time-consuming but we can run them parallelly on different machines. 
Input: Huggingface dataset
Output: a dataset file of minhashes, each corresponding to the minhases of the document to the input dataset.

## Stage 2: Clustering
Perform clustering and note that this stage is not able to run on multiple machines as of now.
Input: a list file each with minhash as the entries (in huggingface dataset format)
Output: a list file with the same size with each entry is a boolean to indicate filtered or not

## Stage 3: Filtering
Perform filtering based one the result of previous stages.
Input: a huggingface dataset and the corresponding indicate file
Output: a huggingface dataset with the indicated true entries removed.